### PR TITLE
Fixes for Vite support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,60 @@
 {
   "name": "vue-barcode-reader",
-  "version": "0.0.1",
-  "lockfileVersion": 1,
+  "version": "1.0.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "vue-barcode-reader",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@zxing/library": "^0.19.1"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.19.1.tgz",
+      "integrity": "sha512-rKwvl3Uuqs8yf364iU9l3HDDaIx8yPv+CH6DbtQaQr67VdKLG22G1ukEp9fOdDefE6tpLtRAdMnTrgtpiaKAZw==",
+      "dependencies": {
+        "ts-custom-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "optional": true
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.1.1.tgz",
+      "integrity": "sha512-f/syoy+pTE4z82qaiRuthEeZtCGNKzlfs0Zc8jpQFcz/CYMaFSwFSdfFt1sSFnPlDLOEm7RCROdIxZ44N8UlwA==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    }
+  },
   "dependencies": {
     "@zxing/library": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.15.1.tgz",
-      "integrity": "sha512-YeQbmY2nWpIBgR9i74mDnoYxJPSvY7Zy0Zz6+KDCQ+wLb20++9dX2v1iH3Wt/kZ5pntqS0K0V5eZkuk4SibbEw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.19.1.tgz",
+      "integrity": "sha512-rKwvl3Uuqs8yf364iU9l3HDDaIx8yPv+CH6DbtQaQr67VdKLG22G1ukEp9fOdDefE6tpLtRAdMnTrgtpiaKAZw==",
       "requires": {
-        "text-encoding": "^0.7.0",
+        "@zxing/text-encoding": "~0.9.0",
         "ts-custom-error": "^3.0.0"
       }
     },
-    "text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
       "optional": true
     },
     "ts-custom-error": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-barcode-reader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vue barcodes and QR codes scanner",
   "main": "src/index.js",
   "scripts": {
@@ -17,12 +17,12 @@
     "zxing"
   ],
   "author": "olefirenko <dmitriy.olefirenko@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/olefirenko/vue-barcode-reader/issues"
   },
   "homepage": "https://github.com/olefirenko/vue-barcode-reader#readme",
   "dependencies": {
-    "@zxing/library": "^0.15.1"
+    "@zxing/library": "^0.19.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import ImageBarcodeReader from "./components/ImageBarcodeReader";
-import StreamBarcodeReader from "./components/StreamBarcodeReader";
+import ImageBarcodeReader from "./components/ImageBarcodeReader.vue";
+import StreamBarcodeReader from "./components/StreamBarcodeReader.vue";
 
 export { ImageBarcodeReader, StreamBarcodeReader };


### PR DESCRIPTION
There is the following error in the version `1.0.0`
```
Uncaught SyntaxError: The requested module '/node_modules/@zxing/library/esm5/index.js?v=3e2bb531' does not provide an export named 'BrowserMultiFormatReader'
```
This PR adds fixes it  and enables the Vite builds.