### PR TITLE
fixed issue with this.codeReader.reset() lifeCycle hook

### DIFF
--- a/src/components/StreamBarcodeReader.vue
+++ b/src/components/StreamBarcodeReader.vue
@@ -38,7 +38,7 @@ export default {
         };
     },
 
-    beforeUnmount() {
+    beforeDestroy() {
         this.codeReader.reset();
     },
 


### PR DESCRIPTION
the `reset()` method was inside a hook called  `beforeUnmount()` there is no such hook in vue so it never got called. this caused the camera to still be running even after destroying the StreamBarcodeReader.
Instead, I changed `beforeUnmount()` to `beforeDestroy()` and now it's working fine :)