### PR TITLE
change codeReader to a prop, so it can be reused for multiple instances

### DIFF
--- a/src/components/StreamBarcodeReader.vue
+++ b/src/components/StreamBarcodeReader.vue
@@ -13,11 +13,16 @@ import { BrowserMultiFormatReader, Exception } from "@zxing/library";
 
 export default {
   name: "stream-barcode-reader",
-
+  props: {
+    codeReader: {
+      required: false,
+      type: Object,
+      default: new BrowserMultiFormatReader()
+    }
+  },
   data() {
     return {
       isLoading: true,
-      codeReader: new BrowserMultiFormatReader(),
       isMediaStreamAPISupported: navigator && navigator.mediaDevices && "enumerateDevices" in navigator.mediaDevices,
     };
   },


### PR DESCRIPTION
If multiple instances of barcode reader are used, the loading time will be extremely long and the web page become laggy. 
This can be solved by declaring BrowserMultiFormatReader() in a parent component and sharing it with other barcode reader instances using prop. The codeReader also has a default value: new BrowserMultiFormatReader(), if only one barcode reader instance is used