### PR TITLE
fix a spelling error in the readme file form libraty to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The library emits the following events:
 
 ### loaded
 
-When the libraty is loaded and the camera is ready to scan
+When the library is loaded and the camera is ready to scan
 
 ### decode
 


### PR DESCRIPTION
1. fix a spelling error in the readme file form libraty to library